### PR TITLE
Add global `shadow-card` class and replace all card shadows with it

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -68,7 +68,9 @@ export const userData =
     "corporateLevel": "10",
     "lifeTime": "2.5",
     "vacationDaysLeft": 14,
-    "sickDaysLeft": 3
+    "sickDaysLeft": 3,
+    "vacationRequestsNumber": 10,
+    "leaveRequestsNumber": 10,
 };
 
 export const carouselItemsData = [

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -3,6 +3,8 @@ import { getTopvacationRequestsCardsData, userData, carouselItemsData } from "./
 
 document.addEventListener("DOMContentLoaded", () => {
 
+  fillUserGeneralInfo();
+
   renderUserQuickProfile();
 
   printLatestNewsCarousel(carouselItemsData);
@@ -10,6 +12,18 @@ document.addEventListener("DOMContentLoaded", () => {
   printSearchableVacationRequestsCardsPanel();
 });
 
+//fill User general info like username in welcom and no of vacation request and number of leave request
+function fillUserGeneralInfo() {
+
+  let userName = document.getElementById("user-name");
+  userName.innerText = userData.username.split(" ")[0];
+
+  let vacationRequestNumber = document.getElementById("vacation-requests-number");
+  let leaveRequestNumber = document.getElementById("leave-requests-number");
+
+  vacationRequestNumber.innerText = userData.vacationRequestsNumber;
+  leaveRequestNumber.innerText = userData.leaveRequestsNumber;
+}
 
 function renderUserQuickProfile() {
   let userProfile = new UserProfile(
@@ -114,7 +128,7 @@ function getVacationRequestsCardElement(vacationRequestsCardData) {
   cardElementTemp.innerHTML = `
      <div class="col cards-panel__item">
                 <div
-                  class="vacation-requests-card shadow-sm text-center bg-background p-3 rounded"
+                  class="vacation-requests-card shadow-card text-center bg-background p-3 rounded"
                 >
                   <header>
                     <img

--- a/scripts/profiles.js
+++ b/scripts/profiles.js
@@ -75,7 +75,7 @@ function getVacationHistoryCardEl(historyCardData) {
   historyCardWrapper.innerHTML = `
         <div class="col">
             <div
-            class="vacation-history-card shadow-sm p-3 bg-background rounded"
+            class="vacation-history-card shadow-card p-3 bg-background rounded"
             >
             <h2 class="fs-5 fw-semibold">${historyCardData.vacationType}</h2>
             <p class="text-secondary mb-3 fw-medium">
@@ -96,9 +96,9 @@ function getPendingCardEl(pendingCardData) {
   let cardElementTemp = document.createElement("div");
 
   cardElementTemp.innerHTML = `
-       <div class="col cards-panel__item">
+       <div class="col cards-panel__item ">
                   <div
-                    class="vacation-requests-card shadow-sm text-center bg-background p-3 rounded"
+                    class="vacation-requests-card shadow-card  text-center bg-background p-3 rounded"
                   >
                     <header>
                       <img

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -80,7 +80,7 @@ function getVacationRequestsCardElement(vacationRequestsCardData) {
 
     cardElementTemp.innerHTML = `
     <div class="col cards-panel__item">
-        <div class="vacation-requests-card position-relative text-center bg-background p-3 rounded">
+        <div class="vacation-requests-card shadow-card position-relative text-center bg-background p-3 rounded">
             <span class='vacation-requests-card__select-icon position-absolute top-0 end-0'></span>
             <header class="d-sm-flex align-items-center gap-3">
                 <img loading='lazy'

--- a/styles/general.css
+++ b/styles/general.css
@@ -18,6 +18,15 @@ html{
     width: fit-content;
 }
 
+.shadow-card{
+    box-shadow: rgba(0, 0, 0, 0.24)  0px 3px 4px;
+    transition: .3s;
+}
+
+.shadow-card:hover{
+    box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
+}
+
 .fs-14{
     font-size: 0.875rem;
 }

--- a/styles/requests.css
+++ b/styles/requests.css
@@ -43,15 +43,6 @@
     height: 5rem;
 }
 
-.vacation-requests-card{
-    box-shadow: rgba(0, 0, 0, 0.24)  0px 3px 4px;
-    transition: .3s;
-}
-
-.vacation-requests-card:hover{
-    box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
-}
-
 .vacation-requests-card__select-icon::after{
     content: "\f058";
     position: absolute;


### PR DESCRIPTION
Add global `shadow-card` class and replace all card shadows with it

- Introduced a global class `shadow-card` to standardize card shadow styling across the application.
- Replaced individual card shadow styles with the new `shadow-card` class for consistency and easier maintenance.